### PR TITLE
Added explicit extra-android-support travis dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ android:
   - android-23
   - extra-android-m2repository
   - extra-android-support
+  - doc-23
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ android:
   - build-tools-23.0.2
   - android-23
   - extra-android-m2repository
+  - extra-android-support
 branches:
   only:
   - master

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha9'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Still not exactly sure why Travis is not able to find certain classes in the support library. Without being able to reproduce locally this may take some testing inside a pull request.