### PR TITLE
Catch JSON exceptions

### DIFF
--- a/gandalf/src/main/java/io/github/btkelly/gandalf/Gandalf.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/Gandalf.java
@@ -21,8 +21,6 @@ import android.support.annotation.Nullable;
 
 import com.google.gson.JsonDeserializer;
 
-import java.io.IOException;
-
 import io.github.btkelly.gandalf.checker.DefaultHistoryChecker;
 import io.github.btkelly.gandalf.checker.DefaultVersionChecker;
 import io.github.btkelly.gandalf.checker.GateKeeper;
@@ -138,7 +136,7 @@ public final class Gandalf {
                     }
 
                     @Override
-                    public void onError(IOException e) {
+                    public void onError(Exception e) {
                         LoggerUtil.logE("Error fetching bootstrap: " + e.getMessage());
                         //In any error case we should let the user in as to not block based on a bug
                         gandalfCallback.onNoActionRequired();

--- a/gandalf/src/main/java/io/github/btkelly/gandalf/network/BootstrapApi.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/network/BootstrapApi.java
@@ -113,14 +113,17 @@ public class BootstrapApi {
                 try {
                     BootstrapResponse bootstrapResponse = gson.fromJson(response.body().string(), BootstrapResponse.class);
                     final Bootstrap bootstrap = bootstrapResponse.getAndroid();
-
-                    new Handler(Looper.getMainLooper()).post(new Runnable() {
-                        @Override
-                        public void run() {
-                            bootstrapCallback.onSuccess(bootstrap);
-                        }
-                    });
-                } catch (JsonSyntaxException e) {
+                    if (bootstrap != null) {
+                        new Handler(Looper.getMainLooper()).post(new Runnable() {
+                            @Override
+                            public void run() {
+                                bootstrapCallback.onSuccess(bootstrap);
+                            }
+                        });
+                    } else {
+                        throw new NullPointerException("No \"android\" key found in the JSON response");
+                    }
+                } catch (JsonSyntaxException | NullPointerException e) {
                     bootstrapCallback.onError(e);
                 }
             }

--- a/gandalf/src/main/java/io/github/btkelly/gandalf/network/BootstrapApi.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/network/BootstrapApi.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSyntaxException;
 
 import java.io.File;
 import java.io.IOException;
@@ -109,15 +110,19 @@ public class BootstrapApi {
 
                 Gson gson = gsonBuilder.create();
 
-                BootstrapResponse bootstrapResponse = gson.fromJson(response.body().string(), BootstrapResponse.class);
-                final Bootstrap bootstrap = bootstrapResponse.getAndroid();
+                try {
+                    BootstrapResponse bootstrapResponse = gson.fromJson(response.body().string(), BootstrapResponse.class);
+                    final Bootstrap bootstrap = bootstrapResponse.getAndroid();
 
-                new Handler(Looper.getMainLooper()).post(new Runnable() {
-                    @Override
-                    public void run() {
-                        bootstrapCallback.onSuccess(bootstrap);
-                    }
-                });
+                    new Handler(Looper.getMainLooper()).post(new Runnable() {
+                        @Override
+                        public void run() {
+                            bootstrapCallback.onSuccess(bootstrap);
+                        }
+                    });
+                } catch (JsonSyntaxException e) {
+                    bootstrapCallback.onError(e);
+                }
             }
         });
     }

--- a/gandalf/src/main/java/io/github/btkelly/gandalf/network/BootstrapCallback.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/network/BootstrapCallback.java
@@ -15,8 +15,6 @@
  */
 package io.github.btkelly.gandalf.network;
 
-import java.io.IOException;
-
 import io.github.btkelly.gandalf.models.Bootstrap;
 
 /**
@@ -26,6 +24,6 @@ import io.github.btkelly.gandalf.models.Bootstrap;
 public interface BootstrapCallback {
 
     void onSuccess(Bootstrap bootstrap);
-    void onError(IOException e);
+    void onError(Exception e);
 
 }


### PR DESCRIPTION
Badly formatted JSON causes crash. 

Cases tested : 
- Empty JSON file
- JSON file with random content
- JSON file with no `android` key in it

This PR ensures that JSON is valid without crashing, and go through `onError` if the JSON is not valid.