### PR TITLE
Catch NPE if response is empty

### DIFF
--- a/gandalf/src/main/java/io/github/btkelly/gandalf/network/BootstrapApi.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/network/BootstrapApi.java
@@ -110,16 +110,20 @@ public class BootstrapApi {
 
                 try {
                     BootstrapResponse bootstrapResponse = gson.fromJson(response.body().string(), BootstrapResponse.class);
-                    final Bootstrap bootstrap = bootstrapResponse.getAndroid();
-                    if (bootstrap != null) {
-                        new Handler(Looper.getMainLooper()).post(new Runnable() {
-                            @Override
-                            public void run() {
-                                bootstrapCallback.onSuccess(bootstrap);
-                            }
-                        });
+                    if (bootstrapResponse != null) {
+                        final Bootstrap bootstrap = bootstrapResponse.getAndroid();
+                        if (bootstrap != null) {
+                            new Handler(Looper.getMainLooper()).post(new Runnable() {
+                                @Override
+                                public void run() {
+                                    bootstrapCallback.onSuccess(bootstrap);
+                                }
+                            });
+                        } else {
+                            postError(bootstrapCallback, new BootstrapException("No \"android\" key found in the JSON response"));
+                        }
                     } else {
-                        postError(bootstrapCallback, new BootstrapException("No \"android\" key found in the JSON response"));
+                        postError(bootstrapCallback, new BootstrapException("No content found in the JSON response"));
                     }
                 } catch (JsonSyntaxException e) {
                     postError(bootstrapCallback, e);


### PR DESCRIPTION
As Gnag asked to not catch NPE, we did not catch the NPE produced when the response body is empty. So when the JSON file/received answer is empty, the app is crashing.

To avoid this, without catching the NPE, I just null-checked the answer !

