### PR TITLE
Removed application element from library's manifest

### DIFF
--- a/gandalf/src/main/AndroidManifest.xml
+++ b/gandalf/src/main/AndroidManifest.xml
@@ -3,11 +3,4 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
This PR fixes #61 by removing the application element in the library's AndroidManifest.xml as it is not needed and can conflict with consumer's manifest attributes when merging manifests during build process.