### PR TITLE
Consumer proguard rules

### DIFF
--- a/gandalf/build.gradle
+++ b/gandalf/build.gradle
@@ -23,6 +23,7 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName versionString
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     lintOptions {

--- a/gandalf/proguard-rules.pro
+++ b/gandalf/proguard-rules.pro
@@ -9,11 +9,18 @@
 
 # Add any project specific keep options here:
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
 -keep class io.github.btkelly.gandalf.models.** { *; }
+
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-keep class sun.misc.Unsafe { *; }
+#-keep class com.google.gson.stream.** { *; }
+
+# Application classes that will be serialized/deserialized over Gson
+-keep class com.google.gson.examples.android.model.** { *; }

--- a/gandalf/proguard-rules.pro
+++ b/gandalf/proguard-rules.pro
@@ -15,3 +15,5 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keep class io.github.btkelly.gandalf.models.** { *; }


### PR DESCRIPTION
This PR adds a proguard rule to keep model classes from being obfuscated when using minifyEnabled during builds. This also sets the proguard file in the consumer proguard files so any consumer of this library does not have to add the proguard rules themselves.