### PR TITLE
New onError callback

### DIFF
--- a/example/src/main/java/io/github/btkelly/gandalf/example/activities/SplashActivity.java
+++ b/example/src/main/java/io/github/btkelly/gandalf/example/activities/SplashActivity.java
@@ -22,17 +22,21 @@ import android.content.Context;
 import android.content.Intent;
 import android.preference.PreferenceManager;
 import android.support.annotation.RawRes;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import io.github.btkelly.gandalf.activities.GandalfActivity;
 import io.github.btkelly.gandalf.example.R;
 import io.github.btkelly.gandalf.example.utils.MockWebServerUtil;
+import io.github.btkelly.gandalf.models.GandalfException;
 
 /**
  * An example splash activity that demonstrates the simplest way to add Gandalf to a project
  */
 public class SplashActivity extends GandalfActivity {
+
+    private static final String TAG = SplashActivity.class.getName();
 
     @Override
     public void youShallPass() {
@@ -82,13 +86,19 @@ public class SplashActivity extends GandalfActivity {
                 PreferenceManager.getDefaultSharedPreferences(this.getApplicationContext())
                         .edit()
                         .clear()
-                        .commit();
+                        .apply();
 
                 restartApp(R.raw.no_action_bootstrap);
                 break;
         }
 
         return true;
+    }
+
+    @Override
+    public void onError(GandalfException gandalfException) {
+        Log.e(TAG, "Error executing Gandalf", gandalfException);
+        youShallPass();
     }
 
     @SuppressLint("CommitPrefEdits")

--- a/gandalf/src/main/java/io/github/btkelly/gandalf/checker/DefaultVersionChecker.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/checker/DefaultVersionChecker.java
@@ -20,6 +20,7 @@ import android.support.annotation.NonNull;
 import io.github.btkelly.gandalf.models.Alert;
 import io.github.btkelly.gandalf.models.AppVersionDetails;
 import io.github.btkelly.gandalf.models.BootstrapException;
+import io.github.btkelly.gandalf.models.GandalfException;
 import io.github.btkelly.gandalf.models.OptionalUpdate;
 import io.github.btkelly.gandalf.models.RequiredUpdate;
 import io.github.btkelly.gandalf.utils.StringUtils;
@@ -35,9 +36,10 @@ public class DefaultVersionChecker implements VersionChecker {
      * @param requiredUpdate current required version information
      * @param appVersionDetails details about the current version of the install app
      * @return {@code true} if app's version is less than the required version
+     * @throws GandalfException the versionCode is not a valid integer
      */
     @Override
-    public boolean showRequiredUpdate(@NonNull final RequiredUpdate requiredUpdate, @NonNull final AppVersionDetails appVersionDetails) {
+    public boolean showRequiredUpdate(@NonNull final RequiredUpdate requiredUpdate, @NonNull final AppVersionDetails appVersionDetails) throws GandalfException {
 
         final String minimumVersionString = requiredUpdate.getMinimumVersion();
 
@@ -50,7 +52,7 @@ public class DefaultVersionChecker implements VersionChecker {
             return appVersionDetails.getVersionCode() < minimumVersion;
 
         } catch (NumberFormatException e) {
-            throw new BootstrapException("Invalid number format on RequiredUpdate version", e);
+            throw new GandalfException("Invalid number format on RequiredUpdate version", e);
         }
     }
 
@@ -60,9 +62,10 @@ public class DefaultVersionChecker implements VersionChecker {
      * @param optionalUpdate current optional version information
      * @param appVersionDetails details about the current version of the installed app
      * @return {@code true} if app's version is behind the optional version
+     * @throws GandalfException the versionCode is not a valid integer
      */
     @Override
-    public boolean showOptionalUpdate(@NonNull final OptionalUpdate optionalUpdate, @NonNull final AppVersionDetails appVersionDetails) {
+    public boolean showOptionalUpdate(@NonNull final OptionalUpdate optionalUpdate, @NonNull final AppVersionDetails appVersionDetails) throws GandalfException {
         final String optionalVersionString = optionalUpdate.getOptionalVersion();
 
         if (StringUtils.isBlank(optionalVersionString)) {
@@ -74,7 +77,7 @@ public class DefaultVersionChecker implements VersionChecker {
             return appVersionDetails.getVersionCode() < optionalVersionCode;
 
         } catch (NumberFormatException e) {
-            throw new BootstrapException("Invalid number format on OptionalUpdate version", e);
+            throw new GandalfException("Invalid number format on OptionalUpdate version", e);
         }
     }
 

--- a/gandalf/src/main/java/io/github/btkelly/gandalf/checker/GateKeeper.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/checker/GateKeeper.java
@@ -24,6 +24,7 @@ import io.github.btkelly.gandalf.models.Alert;
 import io.github.btkelly.gandalf.models.AppVersionDetails;
 import io.github.btkelly.gandalf.models.Bootstrap;
 import io.github.btkelly.gandalf.models.BootstrapException;
+import io.github.btkelly.gandalf.models.GandalfException;
 import io.github.btkelly.gandalf.models.OptionalUpdate;
 import io.github.btkelly.gandalf.models.RequiredUpdate;
 
@@ -53,8 +54,9 @@ public class GateKeeper {
      * Checks version of installed app against the {@link Bootstrap}.
      * @param bootstrap - provided version requirements
      * @return true if the app's version is lower than required
+     * @throws GandalfException the versionCode is not a valid integer
      */
-    public boolean updateIsRequired(@NonNull final Bootstrap bootstrap) {
+    public boolean updateIsRequired(@NonNull final Bootstrap bootstrap) throws GandalfException {
         final RequiredUpdate requiredUpdate = bootstrap.getRequiredUpdate();
 
         return requiredUpdate != null
@@ -65,8 +67,9 @@ public class GateKeeper {
      * Checks version of installed app against the {@link Bootstrap}.
      * @param bootstrap - provided version requirements
      * @return true if an update is available and hasn't been recorded in history
+     * @throws GandalfException the versionCode is not a valid integer
      */
-    public boolean updateIsOptional(@NonNull final Bootstrap bootstrap) {
+    public boolean updateIsOptional(@NonNull final Bootstrap bootstrap) throws GandalfException {
         final OptionalUpdate optionalUpdate = bootstrap.getOptionalUpdate();
 
         return optionalUpdate != null

--- a/gandalf/src/main/java/io/github/btkelly/gandalf/checker/VersionChecker.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/checker/VersionChecker.java
@@ -17,6 +17,7 @@ package io.github.btkelly.gandalf.checker;
 
 import io.github.btkelly.gandalf.models.Alert;
 import io.github.btkelly.gandalf.models.AppVersionDetails;
+import io.github.btkelly.gandalf.models.GandalfException;
 import io.github.btkelly.gandalf.models.OptionalUpdate;
 import io.github.btkelly.gandalf.models.RequiredUpdate;
 
@@ -30,16 +31,18 @@ public interface VersionChecker {
      * @param requiredUpdate current required version information
      * @param appVersionDetails details about the current version of the install app
      * @return {@code true} if {@code requiredUpdate} should be shown
+     * @throws GandalfException the versionCode is not a valid integer
      */
-    boolean showRequiredUpdate(RequiredUpdate requiredUpdate, AppVersionDetails appVersionDetails);
+    boolean showRequiredUpdate(RequiredUpdate requiredUpdate, AppVersionDetails appVersionDetails) throws GandalfException;
 
     /**
      * Checks if the {@link OptionalUpdate} should be shown.
      * @param optionalUpdate current optional version information
      * @param appVersionDetails details about the current version of the installed app
      * @return {@code true} if {@code optionalUpdate} should be shown
+     * @throws GandalfException the versionCode is not a valid integer
      */
-    boolean showOptionalUpdate(OptionalUpdate optionalUpdate, AppVersionDetails appVersionDetails);
+    boolean showOptionalUpdate(OptionalUpdate optionalUpdate, AppVersionDetails appVersionDetails) throws GandalfException;
 
     /**
      * Checks if the {@link Alert} should be shown.

--- a/gandalf/src/main/java/io/github/btkelly/gandalf/models/GandalfException.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/models/GandalfException.java
@@ -15,7 +15,6 @@
  */
 package io.github.btkelly.gandalf.models;
 
-
 public class GandalfException extends Exception {
 
     public GandalfException(Exception e) {

--- a/gandalf/src/main/java/io/github/btkelly/gandalf/models/GandalfException.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/models/GandalfException.java
@@ -13,19 +13,16 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.github.btkelly.gandalf;
+package io.github.btkelly.gandalf.models;
 
-import io.github.btkelly.gandalf.models.Alert;
-import io.github.btkelly.gandalf.models.GandalfException;
-import io.github.btkelly.gandalf.models.OptionalUpdate;
-import io.github.btkelly.gandalf.models.RequiredUpdate;
 
-public interface GandalfCallback {
+public class GandalfException extends Exception {
 
-    void onRequiredUpdate(RequiredUpdate requiredUpdate);
-    void onOptionalUpdate(OptionalUpdate optionalUpdate);
-    void onAlert(Alert alert);
-    void onNoActionRequired();
-    void onError(GandalfException gandalfException);
+    public GandalfException(Exception e) {
+        super(e);
+    }
 
+    public GandalfException(String s, Throwable e) {
+        super(s, e);
+    }
 }

--- a/gandalf/src/test/java/io/github/btkelly/gandalf/checker/GateKeeperTest.java
+++ b/gandalf/src/test/java/io/github/btkelly/gandalf/checker/GateKeeperTest.java
@@ -29,6 +29,7 @@ import org.mockito.MockitoAnnotations;
 import io.github.btkelly.gandalf.models.Alert;
 import io.github.btkelly.gandalf.models.AppVersionDetails;
 import io.github.btkelly.gandalf.models.Bootstrap;
+import io.github.btkelly.gandalf.models.GandalfException;
 import io.github.btkelly.gandalf.models.OptionalUpdate;
 import io.github.btkelly.gandalf.models.RequiredUpdate;
 
@@ -72,60 +73,73 @@ public class GateKeeperTest {
 
     //RequiredUpdate tests
     @Test
-    public void showRequiredUpdateShouldReturnFalseWhenRequiredUpdateIsNull() {
+    public void showRequiredUpdateShouldReturnFalseWhenRequiredUpdateIsNull() throws GandalfException {
         when(mockBootstrap.getRequiredUpdate()).thenReturn(null);
 
         Assert.assertFalse("RequiredUpdate is null, this should be false", subject.updateIsRequired(mockBootstrap));
     }
 
     @Test
-    public void showRequiredUpdateShouldBeTrueWhenVersionCheckRequiresUpdate() {
+    public void showRequiredUpdateShouldBeTrueWhenVersionCheckRequiresUpdate() throws GandalfException {
         when(mockVersionChecker.showRequiredUpdate(Mockito.any(RequiredUpdate.class), Mockito.any(AppVersionDetails.class))).thenReturn(true);
 
         Assert.assertTrue(ASSERT_TRUE_MESSAGE, subject.updateIsRequired(mockBootstrap));
     }
 
     @Test
-    public void showRequiredUpdateShouldBeFalseWhenVersionCheckFalse() {
+    public void showRequiredUpdateShouldBeFalseWhenVersionCheckFalse() throws GandalfException {
         when(mockVersionChecker.showRequiredUpdate(Mockito.any(RequiredUpdate.class), Mockito.any(AppVersionDetails.class))).thenReturn(false);
 
         Assert.assertFalse(ASSERT_FALSE_MESSAGE, subject.updateIsRequired(mockBootstrap));
     }
 
+    @Test(expected = GandalfException.class)
+    public void showRequiredUpdateShouldThrowExceptionWhenExceptionIsThrown() throws GandalfException {
+        when(mockVersionChecker.showRequiredUpdate(Mockito.any(RequiredUpdate.class), Mockito.any(AppVersionDetails.class))).thenThrow(GandalfException.class);
+        subject.updateIsRequired(mockBootstrap);
+    }
+
     //OptionalUpdate tests
     @Test
-    public void showOptionalUpdateShouldBeFalseIfOptionalUpdateIsNull() {
+    public void showOptionalUpdateShouldBeFalseIfOptionalUpdateIsNull() throws GandalfException {
         when(mockBootstrap.getOptionalUpdate()).thenReturn(null);
 
         Assert.assertFalse("OptionalUpdate is null, should be false", subject.updateIsOptional(mockBootstrap));
     }
 
     @Test
-    public void showOptionalUpdateShouldBeTrueWithAvailableTrueAndHistoryFalse() {
+    public void showOptionalUpdateShouldBeTrueWithAvailableTrueAndHistoryFalse() throws GandalfException {
         setOptionalUpdateScenario(true, false);
 
         Assert.assertTrue(ASSERT_TRUE_MESSAGE, subject.updateIsOptional(mockBootstrap));
     }
 
     @Test
-    public void showOptionalUpdateShouldBeFalseWithAvailableTrueAndHistoryTrue() {
+    public void showOptionalUpdateShouldBeFalseWithAvailableTrueAndHistoryTrue() throws GandalfException {
         setOptionalUpdateScenario(true, true);
 
         Assert.assertFalse(ASSERT_FALSE_MESSAGE, subject.updateIsOptional(mockBootstrap));
     }
 
     @Test
-    public void showOptionalUpdateShouldBeFalseWithAvailableFalseAndHistoryFalse() {
+    public void showOptionalUpdateShouldBeFalseWithAvailableFalseAndHistoryFalse() throws GandalfException {
         setOptionalUpdateScenario(false, false);
 
         Assert.assertFalse(ASSERT_FALSE_MESSAGE, subject.updateIsOptional(mockBootstrap));
     }
 
     @Test
-    public void showOptionalUpdateShouldBeFalseWithAvailableFalseAndHistoryTrue() {
+    public void showOptionalUpdateShouldBeFalseWithAvailableFalseAndHistoryTrue() throws GandalfException {
         setOptionalUpdateScenario(false, true);
 
         Assert.assertFalse(ASSERT_FALSE_MESSAGE, subject.updateIsOptional(mockBootstrap));
+    }
+
+    @Test(expected = GandalfException.class)
+    public void showOptionalUpdateShouldThrowExceptionWhenExceptionIsThrown() throws GandalfException {
+        when(mockVersionChecker.showOptionalUpdate(Mockito.any(OptionalUpdate.class),
+                Mockito.any(AppVersionDetails.class))).thenThrow(GandalfException.class);
+        subject.updateIsOptional(mockBootstrap);
     }
 
 
@@ -170,7 +184,7 @@ public class GateKeeperTest {
         when(mockHistoryChecker.contains(Mockito.any(Alert.class))).thenReturn(alertMatchesHistory);
     }
 
-    private void setOptionalUpdateScenario(final boolean updateAvailable, final boolean updateMatchesHistory) {
+    private void setOptionalUpdateScenario(final boolean updateAvailable, final boolean updateMatchesHistory) throws GandalfException {
         when(mockVersionChecker.showOptionalUpdate(Mockito.any(OptionalUpdate.class),
                 Mockito.any(AppVersionDetails.class))).thenReturn(updateAvailable);
         when(mockHistoryChecker.contains(Mockito.any(OptionalUpdate.class))).thenReturn(updateMatchesHistory);


### PR DESCRIPTION
###What does this PR do?
1. Add new checked exception `GandalfException`
2. Add new callback method `onError`
3. Have version checker thrown `GandalfException` instead of unchecked `BootstratException` when there is error processing JSON
4. Have `Gandalf` trigger `onError` if there is any exception processing JSON or any other error instead of do nothing.
5. Implement the `onError` method in the example module and have it only logged the exception.
6. replace `commit()` with `apply()` asked by the IDE.

Although this make the app not crash anymore, it is adding a new method which will requires the user to change the code if they update the library. I would love to not do that but right now I haven't come up with any other idea.

And I am bad at naming and comment. So please let me know if you feel there is any place that can have a change.