### PR TITLE
Installer: add setter for HistoryChecker and VersionChecker.

### DIFF
--- a/gandalf/src/main/java/io/github/btkelly/gandalf/Gandalf.java
+++ b/gandalf/src/main/java/io/github/btkelly/gandalf/Gandalf.java
@@ -28,6 +28,7 @@ import io.github.btkelly.gandalf.checker.DefaultHistoryChecker;
 import io.github.btkelly.gandalf.checker.DefaultVersionChecker;
 import io.github.btkelly.gandalf.checker.GateKeeper;
 import io.github.btkelly.gandalf.checker.HistoryChecker;
+import io.github.btkelly.gandalf.checker.VersionChecker;
 import io.github.btkelly.gandalf.holders.DialogStringsHolder;
 import io.github.btkelly.gandalf.models.Alert;
 import io.github.btkelly.gandalf.models.Bootstrap;
@@ -208,6 +209,8 @@ public final class Gandalf {
 
         private DialogStringsHolder dialogStringsHolder;
         private Executor callbackExecutor;
+        private HistoryChecker historyChecker;
+        private VersionChecker versionChecker;
 
         public Installer setContext(Context context) {
             this.context = context;
@@ -254,6 +257,16 @@ public final class Gandalf {
             return this;
         }
 
+        public Installer setHistoryChecker(HistoryChecker historyChecker) {
+            this.historyChecker = historyChecker;
+            return this;
+        }
+
+        public Installer setVersionChecker(VersionChecker versionChecker) {
+            this.versionChecker = versionChecker;
+            return this;
+        }
+
         public void install() {
 
             synchronized (Gandalf.class) {
@@ -281,15 +294,21 @@ public final class Gandalf {
                     this.onUpdateSelectedListener = new PlayStoreUpdateListener(this.packageName);
                 }
 
-                HistoryChecker historyChecker = new DefaultHistoryChecker(this.context);
+                if (this.historyChecker == null) {
+                    this.historyChecker = new DefaultHistoryChecker(this.context);
+                }
+
+                if (this.versionChecker == null) {
+                    this.versionChecker = new DefaultVersionChecker();
+                }
 
                 LoggerUtil.setLogLevel(logLevel);
 
                 gandalfInstance = createInstance(
                         this.okHttpClient,
                         this.bootstrapUrl,
-                        historyChecker,
-                        new GateKeeper(this.context, new DefaultVersionChecker(), historyChecker),
+                        this.historyChecker,
+                        new GateKeeper(this.context, this.versionChecker, this.historyChecker),
                         this.onUpdateSelectedListener,
                         this.customDeserializer,
                         this.dialogStringsHolder,


### PR DESCRIPTION
Gandalf is great, I really liked it! It provides the most features that my team-project needs.
However, I'd like to add a custom `HistoryChecker` setter (and `VersionChecker` btw) to make it more customizable.

# Issue

In my case, our team hopes that the optional-update-window show up **every time** when user launches the app. However, the `DefaultHistoryChecker` has made the rule: when launched Gandalf, it will check the optional-update version last time saved in local preference, and if it is identical to the version this time, it will make `GateKeeper.updateIsOptional` returns false, causing Gandalf to not show up the window.

# Proposal of Solution

After a little dig into the code, I think it is appropriate to add setter function in `Gandalf.Installer`, as most of other members has been allowed to re-set here, and `HistoryChecker` is designed as an interface. By adding this, I can implement my custom `HistoryChecker`, and hence solve the issue above.

I'm willing to discuss. If you have any thought or suggestion about this, please let me know :)